### PR TITLE
Add ajaxurl to JavaScript localized values

### DIFF
--- a/faq/gutenbergerli-faq.js
+++ b/faq/gutenbergerli-faq.js
@@ -26,7 +26,7 @@ jQuery( document ).ready( function( $ ) {
 		}
 
 		$.ajax({
-			url : ajaxurl,
+			url : mjjGutenbergerli.ajaxurl,
 			type: "POST",
 			data: helpfulnessData,
 			success: function( data, textStatus, jqXHR ) {

--- a/faq/index.php
+++ b/faq/index.php
@@ -47,6 +47,7 @@ function gutenbergerli_faq_enqueue_block_assets() {
 		'gutenbergerli_faq',
 		'mjjGutenbergerli',
 		array(
+			'ajaxurl' => admin_url( 'admin-ajax.php' ),
 			'postId' => $post_id,
 			'helpfulnessNonce' => wp_create_nonce( 'helpfulness_nonce_' . $post->ID ),
 		)


### PR DESCRIPTION
While ajaxurl is a JavaScript value available on the
backend, it is not available on the front-end.

Here we pass the URL as a localized value in PHP and modify
the JavaScript to use the localized value.

Fixes #1